### PR TITLE
Initialize terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,15 @@ venv.bak/
 # pycharm
 .idea/
 
+# vscode
+.vscode
+
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# terraform
+.terraform
+*.tfstate
+*.tfstate.backup

--- a/infra/terraform/global/iam/outputs.tf
+++ b/infra/terraform/global/iam/outputs.tf
@@ -1,0 +1,3 @@
+output "cred" {
+  value = "${var.cred}"
+}

--- a/infra/terraform/global/iam/vars.tf
+++ b/infra/terraform/global/iam/vars.tf
@@ -1,0 +1,4 @@
+variable "cred" {
+  description = "The location of aws credential file"
+  default     = "/home/lsetiawan/.aws/credentials"
+}

--- a/infra/terraform/mgmt/services/bastion-host/main.tf
+++ b/infra/terraform/mgmt/services/bastion-host/main.tf
@@ -1,0 +1,51 @@
+module "iam" {
+  source = "../../../global/iam"
+}
+
+provider "aws" {
+  region                  = "${var.region}"
+  shared_credentials_file = "${module.iam.cred}"
+}
+
+resource "aws_instance" "io2-bastion" {
+  ami                    = "ami-ba602bc2"
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = ["${aws_security_group.io2-bastion-sc.id}"]
+
+  user_data = <<-EOF
+              #!/bin/bash
+              echo "Hello, World" > index.html
+              nohup busybox httpd -f -p "${var.server_port}" &
+              EOF
+
+  key_name = "${aws_key_pair.don-laptop.key_name}"
+
+  tags {
+    Name    = "io2-bastion-test"
+    Owner   = "Don"
+    Project = "IO2 Portal"
+  }
+}
+
+resource "aws_security_group" "io2-bastion-sc" {
+  name = "io2-bastion-sc"
+
+  ingress {
+    from_port   = "${var.server_port}"
+    to_port     = "${var.server_port}"
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = "${var.ssh_port}"
+    to_port     = "${var.ssh_port}"
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_key_pair" "don-laptop" {
+  key_name   = "don-laptop"
+  public_key = "${file("${var.ssh_key_location}")}"
+}

--- a/infra/terraform/mgmt/services/bastion-host/outputs.tf
+++ b/infra/terraform/mgmt/services/bastion-host/outputs.tf
@@ -1,0 +1,3 @@
+output "io2-bastion-ip" {
+  value = "${aws_instance.io2-bastion.public_ip}"
+}

--- a/infra/terraform/mgmt/services/bastion-host/vars.tf
+++ b/infra/terraform/mgmt/services/bastion-host/vars.tf
@@ -1,0 +1,18 @@
+variable "server_port" {
+  description = "The port the server will use for HTTP requests"
+  default     = 8080
+}
+
+variable "ssh_port" {
+  description = "The port for SSH connection"
+  default     = 22
+}
+
+variable "region" {
+  description = "Desired aws region"
+  default     = "us-west-2"
+}
+
+variable "ssh_key_location" {
+  default = "/home/lsetiawan/.ssh/id_rsa.pub"
+}


### PR DESCRIPTION
## Overview

Add terraform templates to initialize the building of backend infrastructure. The current setup only tries the terraform example of making a simple web server. From the template file, a bastion server is created. 